### PR TITLE
Release 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
   - 0.10

--- a/History.md
+++ b/History.md
@@ -1,11 +1,16 @@
+1.0.1 / 2015-03-04
+==================
 
-1.0.0 / 2013-06-08 
+  * Merge pull request #2 from simonzack/master
+  * fixes `.stack` on firefox
+
+1.0.0 / 2013-06-08
 ==================
 
   * readme: change travis and component urls
   * refactor: [*] prepare for move to chaijs gh org
 
-0.1.0 / 2013-04-07 
+0.1.0 / 2013-04-07
 ==================
 
   * test: use vanilla test runner/assert

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
     "name": "assertion-error"
   , "repo": "chaijs/assertion-error"
-  , "version": "1.0.0"
+  , "version": "1.0.1"
   , "description": "Error constructor for test and validation frameworks that implements standardized AssertionError specification."
   , "license": "MIT"
   , "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "assertion-error"
-  , "version": "1.0.0"
+  , "version": "1.0.1"
   , "description": "Error constructor for test and validation frameworks that implements standardized AssertionError specification."
   , "author": "Jake Luer <jake@qualiancy.com> (http://qualiancy.com)"
   , "license": "MIT"


### PR DESCRIPTION
@logicalparadox can you please take a look at this and merge when ready - it fixes the `.stack` property in Firefox. You'll need to release this manually as the travis.yml for `assertion-error` does not have auto releases set up.