### PR TITLE
Get stack from thrown error (needed for PhantomJS)

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,11 @@ function AssertionError (message, _props, ssf) {
   if (ssf && Error.captureStackTrace) {
     Error.captureStackTrace(this, ssf);
   } else {
-    this.stack = new Error().stack;
+    try {
+      throw new Error();
+    } catch(e) {
+      this.stack = e.stack;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes chaijs/chai#618 (verified by testing)