### PR TITLE
Copied typings from DefinitelyTyped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Tests
 # 
 
-test: test-node
+test: test-node test-typescript
 
 test-node: 
 	@printf "\n  ==> [Node.js]\n"
@@ -13,6 +13,9 @@ test-browser:
 	@printf "\n  ==> [Browser]\n"
 	@make build
 	@printf "\n\n  Open 'test/index.html' in your browser to test.\n\n"
+
+test-typescript:
+	@./node_modules/.bin/tsc test/typings.ts index.d.ts --noEmit
 
 #
 # Components

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+type AssertionError<T = {}> = Error & T & {
+    showDiff: boolean;
+};
+
+interface AssertionErrorConstructor {
+    new<T = {}>(message: string, props?: T, ssf?: Function): AssertionError<T>;
+}
+
+declare const AssertionError: AssertionErrorConstructor;
+
+export = AssertionError;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1982 @@
+{
+    "name": "assertion-error",
+    "version": "1.0.2",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "JSONStream": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+            "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+            "dev": true,
+            "requires": {
+                "jsonparse": "0.0.5",
+                "through": "2.3.8"
+            }
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "acorn": {
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+            "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+            "dev": true
+        },
+        "adm-zip": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+            "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz",
+            "integrity": "sha1-aJDT+yFwBLYrcPiSjg+uX4lSpwY=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "alter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+            "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+            "dev": true,
+            "requires": {
+                "stable": "0.1.6"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "archy": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
+            "integrity": "sha1-kQ9Dv2YUH8M1VkWXq8GJ30Sz014=",
+            "dev": true
+        },
+        "ast-traverse": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+            "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+            "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+            "dev": true
+        },
+        "autoprefixer-core": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-3.1.2.tgz",
+            "integrity": "sha1-reXOni2dcbt//DHWlvpeh66+tjQ=",
+            "dev": true,
+            "requires": {
+                "caniuse-db": "1.0.30000783",
+                "postcss": "2.2.6"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base62": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+            "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ=",
+            "dev": true
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "breakable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+            "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
+            "dev": true
+        },
+        "builder-autoprefixer": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/builder-autoprefixer/-/builder-autoprefixer-1.0.4.tgz",
+            "integrity": "sha1-nNjDdqbXoXIAvYyjMbUfIwDhrHA=",
+            "dev": true,
+            "requires": {
+                "autoprefixer-core": "3.1.2"
+            }
+        },
+        "builder-es6-module-to-cjs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/builder-es6-module-to-cjs/-/builder-es6-module-to-cjs-1.1.0.tgz",
+            "integrity": "sha1-efMpfRjEe7iLQ5R1OPoccnQnHuM=",
+            "dev": true,
+            "requires": {
+                "es6-module-jstransform": "0.1.4",
+                "is-module": "1.0.0"
+            }
+        },
+        "bytes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+            "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true
+        },
+        "caniuse-db": {
+            "version": "1.0.30000783",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+            "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
+        "chanel": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/chanel/-/chanel-2.2.0.tgz",
+            "integrity": "sha1-JlKVsouSqoIAX4Zd0VpIlMQ42Tw=",
+            "dev": true,
+            "requires": {
+                "co": "3.1.0",
+                "generator-supported": "0.0.1",
+                "to-descriptor": "1.0.1"
+            }
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true
+                }
+            }
+        },
+        "co": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+            "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+            "dev": true
+        },
+        "cogent": {
+            "version": "git://github.com/timaschew/cogent.git#2246bd071392f5053a3a110024fd608a40a593ba",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0",
+                "generator-supported": "0.0.1",
+                "netrc": "0.1.4",
+                "proxy-agent": "1.1.1",
+                "raw-body": "1.3.4",
+                "statuses": "1.4.0",
+                "write-to": "1.1.1"
+            }
+        },
+        "commander": {
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+            "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+            "dev": true
+        },
+        "commoner": {
+            "version": "0.10.8",
+            "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+            "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+            "dev": true,
+            "requires": {
+                "commander": "2.12.2",
+                "detective": "4.7.0",
+                "glob": "5.0.15",
+                "graceful-fs": "4.1.11",
+                "iconv-lite": "0.4.19",
+                "mkdirp": "0.5.1",
+                "private": "0.1.8",
+                "q": "1.5.1",
+                "recast": "0.11.23"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.9.6",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+                    "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+                    "dev": true
+                },
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "recast": {
+                    "version": "0.11.23",
+                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+                    "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+                    "dev": true,
+                    "requires": {
+                        "ast-types": "0.9.6",
+                        "esprima": "3.1.3",
+                        "private": "0.1.8",
+                        "source-map": "0.5.7"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "component": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/component/-/component-1.1.0.tgz",
+            "integrity": "sha1-NgSaold5i37lcUKWHhjgdnkYyao=",
+            "dev": true,
+            "requires": {
+                "co": "3.1.0",
+                "commander": "2.12.2",
+                "component-build": "1.2.2",
+                "component-consoler": "2.0.0",
+                "component-flatten": "1.0.1",
+                "component-ls": "2.1.0",
+                "component-outdated2": "1.0.5",
+                "component-pin": "1.0.5",
+                "component-remotes": "1.2.0",
+                "component-resolver": "1.3.0",
+                "component-search2": "1.1.1",
+                "component-updater": "1.0.5",
+                "component-watcher": "1.0.3",
+                "debug": "3.1.0",
+                "mkdirp": "0.3.5",
+                "rimraf": "2.6.2",
+                "semver": "2.3.2",
+                "superagent": "0.17.0",
+                "tiny-lr-fork": "0.0.5",
+                "win-fork": "1.1.1"
+            }
+        },
+        "component-build": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/component-build/-/component-build-1.2.2.tgz",
+            "integrity": "sha1-1bwl0lIE35On2aN6LeAE4RmkpXw=",
+            "dev": true,
+            "requires": {
+                "builder-autoprefixer": "1.0.4",
+                "builder-es6-module-to-cjs": "1.1.0",
+                "component-builder": "1.2.1",
+                "debug": "3.1.0"
+            }
+        },
+        "component-builder": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-builder/-/component-builder-1.2.1.tgz",
+            "integrity": "sha1-o5fBg3na9RH4Woy5TKDZIcHdsaQ=",
+            "dev": true,
+            "requires": {
+                "chanel": "2.2.0",
+                "co": "3.1.0",
+                "component-flatten": "1.0.1",
+                "component-manifest": "1.0.0",
+                "component-require2": "1.1.1",
+                "cp": "0.1.1",
+                "debug": "3.1.0",
+                "generator-supported": "0.0.1",
+                "graceful-fs": "2.0.3",
+                "mkdirp": "0.3.5",
+                "requires": "1.0.2",
+                "syntax-error": "1.3.0"
+            }
+        },
+        "component-consoler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/component-consoler/-/component-consoler-2.0.0.tgz",
+            "integrity": "sha1-Peq/BGwjm2EGNi7JaJQGNruhTCM=",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0"
+            }
+        },
+        "component-downloader": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/component-downloader/-/component-downloader-1.2.0.tgz",
+            "integrity": "sha1-b/Z/9xyEaoWKrjGog1X5vxrUO20=",
+            "dev": true,
+            "requires": {
+                "chanel": "2.2.0",
+                "co": "3.1.0",
+                "component-consoler": "2.0.0",
+                "component-remotes": "1.2.0",
+                "debug": "3.1.0",
+                "decompress": "0.2.5",
+                "generator-supported": "0.0.1",
+                "graceful-fs": "2.0.3",
+                "mkdirp": "0.3.5",
+                "rimraf": "2.6.2",
+                "semver": "2.3.2",
+                "unglob": "0.1.2",
+                "write-to": "1.1.1"
+            }
+        },
+        "component-flatten": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/component-flatten/-/component-flatten-1.0.1.tgz",
+            "integrity": "sha1-W0n0msRcuIxDAyuXozb1P4fNbIw=",
+            "dev": true,
+            "requires": {
+                "semver": "2.3.2"
+            }
+        },
+        "component-ls": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/component-ls/-/component-ls-2.1.0.tgz",
+            "integrity": "sha1-wR7ez4mDbd6JBkrQT+JK3YClERI=",
+            "dev": true,
+            "requires": {
+                "archy": "0.0.2"
+            }
+        },
+        "component-manifest": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/component-manifest/-/component-manifest-1.0.0.tgz",
+            "integrity": "sha1-SNy7HqPGiHYifmra/PNxJbC81XI=",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0",
+                "generator-supported": "0.0.1",
+                "graceful-fs": "2.0.3",
+                "unglob": "0.1.2"
+            }
+        },
+        "component-outdated2": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/component-outdated2/-/component-outdated2-1.0.5.tgz",
+            "integrity": "sha1-IGbA9Cx1w18tS/3iv5/s4M5GPRQ=",
+            "dev": true,
+            "requires": {
+                "component-consoler": "2.0.0",
+                "component-flatten": "1.0.1",
+                "component-remotes": "1.2.0",
+                "generator-supported": "0.0.1",
+                "semver": "2.3.2"
+            }
+        },
+        "component-pin": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/component-pin/-/component-pin-1.0.5.tgz",
+            "integrity": "sha1-v6lOAepCB18ufU17X3i2Yt24NY0=",
+            "dev": true,
+            "requires": {
+                "component-consoler": "2.0.0",
+                "component-flatten": "1.0.1",
+                "component-remotes": "1.2.0",
+                "generator-supported": "0.0.1",
+                "semver": "2.3.2"
+            }
+        },
+        "component-remotes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/component-remotes/-/component-remotes-1.2.0.tgz",
+            "integrity": "sha1-PQeYpR5ziZxs5VnZN2Olb8eh2IM=",
+            "dev": true,
+            "requires": {
+                "co": "3.1.0",
+                "cogent": "git://github.com/timaschew/cogent.git#2246bd071392f5053a3a110024fd608a40a593ba",
+                "component-consoler": "2.0.0",
+                "component-validator": "1.1.1",
+                "debug": "3.1.0",
+                "generator-supported": "0.0.1",
+                "graceful-fs": "2.0.3",
+                "semver": "2.3.2"
+            }
+        },
+        "component-require2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/component-require2/-/component-require2-1.1.1.tgz",
+            "integrity": "sha1-POrqGYc8HG74X1O48572koWvXMU=",
+            "dev": true
+        },
+        "component-resolver": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-resolver/-/component-resolver-1.3.0.tgz",
+            "integrity": "sha1-79grBa9krRJ4W5h8AfCsQfAKaNw=",
+            "dev": true,
+            "requires": {
+                "chanel": "2.2.0",
+                "co": "3.1.0",
+                "component-consoler": "2.0.0",
+                "component-downloader": "1.2.0",
+                "component-flatten": "1.0.1",
+                "component-remotes": "1.2.0",
+                "component-validator": "1.1.1",
+                "debug": "3.1.0",
+                "generator-supported": "0.0.1",
+                "graceful-fs": "2.0.3",
+                "semver": "2.3.2",
+                "unglob": "0.1.2"
+            }
+        },
+        "component-search2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/component-search2/-/component-search2-1.1.1.tgz",
+            "integrity": "sha1-kmeDygb2Hvdd7YW7ZVuq3i/J65E=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "0.8.4",
+                "bytes": "0.3.0",
+                "cogent": "0.4.3",
+                "component-consoler": "2.0.0",
+                "debug": "3.1.0",
+                "event-stream": "3.3.4",
+                "generator-supported": "0.0.1",
+                "stream-to-array": "1.0.0"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz",
+                    "integrity": "sha1-eOLg4ox/nHuYjqiu4NtNX6mUGTU=",
+                    "dev": true
+                },
+                "cogent": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/cogent/-/cogent-0.4.3.tgz",
+                    "integrity": "sha1-UAdE8R2D6cD8Q+9vlem5zHFaCFQ=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "3.1.0",
+                        "generator-supported": "0.0.1",
+                        "netrc": "0.1.4",
+                        "proxy-agent": "1.1.1",
+                        "raw-body": "1.3.4",
+                        "statuses": "1.4.0",
+                        "write-to": "1.1.1"
+                    }
+                }
+            }
+        },
+        "component-updater": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/component-updater/-/component-updater-1.0.5.tgz",
+            "integrity": "sha1-CHd/ZxzodeE+MHwdghfC6l8aSsQ=",
+            "dev": true,
+            "requires": {
+                "component-consoler": "2.0.0",
+                "component-flatten": "1.0.1",
+                "component-remotes": "1.2.0",
+                "generator-supported": "0.0.1",
+                "semver": "2.3.2"
+            }
+        },
+        "component-validator": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/component-validator/-/component-validator-1.1.1.tgz",
+            "integrity": "sha1-+lD+t/WL7IndaXktE6Mn4lJgjl4=",
+            "dev": true,
+            "requires": {
+                "component-consoler": "2.0.0"
+            }
+        },
+        "component-watcher": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/component-watcher/-/component-watcher-1.0.3.tgz",
+            "integrity": "sha1-wl6AF0sLQFVJXX7xJnmGJm2QxTU=",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0",
+                "sane": "0.8.1"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "cookiejar": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz",
+            "integrity": "sha1-3QCzVnkCHpnL1OhVua0EGRNHR2U=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cp": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/cp/-/cp-0.1.1.tgz",
+            "integrity": "sha1-OUanbBpT/+DmhZPzQcEkszbB8G0=",
+            "dev": true
+        },
+        "data-uri-to-buffer": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz",
+            "integrity": "sha1-RuE6udqOMJdFyNAc5UchPr2y/j8=",
+            "dev": true
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decompress": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+            "integrity": "sha1-0hMjPv4GbM2A2RTXk/GzDNmEuEc=",
+            "dev": true,
+            "requires": {
+                "adm-zip": "0.4.7",
+                "ext-name": "1.0.1",
+                "get-stdin": "0.1.0",
+                "mkdirp": "0.3.5",
+                "nopt": "2.2.1",
+                "rimraf": "2.6.2",
+                "stream-combiner": "0.0.4",
+                "tar": "0.1.20",
+                "tempfile": "0.1.3"
+            }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
+        "defs": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+            "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+            "dev": true,
+            "requires": {
+                "alter": "0.2.0",
+                "ast-traverse": "0.1.1",
+                "breakable": "1.0.0",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "simple-fmt": "0.1.0",
+                "simple-is": "0.2.0",
+                "stringmap": "0.2.2",
+                "stringset": "0.2.1",
+                "tryor": "0.1.2",
+                "yargs": "3.27.0"
+            },
+            "dependencies": {
+                "esprima-fb": {
+                    "version": "15001.1001.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                    "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                    "dev": true
+                }
+            }
+        },
+        "degenerator": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+            "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.10.1",
+                "escodegen": "1.9.0",
+                "esprima": "3.1.3"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                }
+            }
+        },
+        "detective": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.0.tgz",
+            "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.2.1",
+                "defined": "1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+                    "dev": true
+                }
+            }
+        },
+        "dethroy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/dethroy/-/dethroy-1.0.2.tgz",
+            "integrity": "sha1-yCADMXaT3LzaP3UrAYLjvxbdRCE=",
+            "dev": true
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "emitter-component": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz",
+            "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8=",
+            "dev": true
+        },
+        "es6-module-jstransform": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/es6-module-jstransform/-/es6-module-jstransform-0.1.4.tgz",
+            "integrity": "sha1-OtHj6qt0UY9a8jwQFPGCjF6WfAI=",
+            "dev": true,
+            "requires": {
+                "esprima-fb": "3001.1.0-dev-harmony-fb",
+                "jstransform": "3.0.0"
+            }
+        },
+        "escodegen": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+            "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+            "dev": true,
+            "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "esprima-fb": {
+            "version": "3001.1.0-dev-harmony-fb",
+            "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+            "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE=",
+            "dev": true
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+            }
+        },
+        "ext-list": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+            "integrity": "sha1-NhTV8pn0pZKolinn3oJfF3TRmr0=",
+            "dev": true,
+            "requires": {
+                "got": "0.2.0"
+            }
+        },
+        "ext-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+            "integrity": "sha1-GCgzVtxAo5NFXFRGDwWZzpfTDgw=",
+            "dev": true,
+            "requires": {
+                "ext-list": "0.2.0",
+                "underscore.string": "2.3.3"
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "faye-websocket": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+            "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
+            "dev": true
+        },
+        "file-uri-to-path": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz",
+            "integrity": "sha1-N83RtbkFQEs/BeGyNkW+aU/3D4I=",
+            "dev": true
+        },
+        "formidable": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+            "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo=",
+            "dev": true
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fstream": {
+            "version": "0.1.31",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+            "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "3.0.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "3.0.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+                    "dev": true,
+                    "requires": {
+                        "natives": "1.1.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                }
+            }
+        },
+        "ftp": {
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "1.1.14",
+                "xregexp": "2.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                }
+            }
+        },
+        "generator-supported": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/generator-supported/-/generator-supported-0.0.1.tgz",
+            "integrity": "sha1-kivSIBpsONj6y4FdWT2KA8iYwpk=",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
+            "integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+            "dev": true
+        },
+        "get-uri": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-0.1.4.tgz",
+            "integrity": "sha1-NfinlUwSn7Ey/y3fXtgaV8uKnlQ=",
+            "dev": true,
+            "requires": {
+                "data-uri-to-buffer": "0.0.4",
+                "debug": "2.6.9",
+                "extend": "3.0.1",
+                "file-uri-to-path": "0.0.2",
+                "ftp": "0.3.10",
+                "readable-stream": "2.3.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "glob": {
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+            "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimatch": "0.3.0"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                    }
+                }
+            }
+        },
+        "got": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+            "integrity": "sha1-0Awkiyn9zK6pQN+coJlev/MbUaU=",
+            "dev": true,
+            "requires": {
+                "object-assign": "0.3.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+            "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+            "dev": true
+        },
+        "http-proxy-agent": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-0.2.7.tgz",
+            "integrity": "sha1-4X/aZfCQLZUs55IeYsf/iGJlWl4=",
+            "dev": true,
+            "requires": {
+                "agent-base": "1.0.2",
+                "debug": "2.6.9",
+                "extend": "3.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "https-proxy-agent": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
+            "integrity": "sha1-cT+jjl01P1DrFKNC/r4pAz7RYZs=",
+            "dev": true,
+            "requires": {
+                "agent-base": "1.0.2",
+                "debug": "2.6.9",
+                "extend": "3.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "js-base64": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+            "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+            "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+            "dev": true
+        },
+        "jstransform": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
+            "integrity": "sha1-olkats7o2XvzvoMNv6IxO4fNZAs=",
+            "dev": true,
+            "requires": {
+                "base62": "0.1.1",
+                "esprima-fb": "3001.1.0-dev-harmony-fb",
+                "source-map": "0.1.31"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.1.31",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                    "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+            "dev": true
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.4"
+            }
+        },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "methods": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+            "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow=",
+            "dev": true
+        },
+        "mime": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz",
+            "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+            "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+            "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "natives": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+            "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+            "dev": true
+        },
+        "netmask": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+            "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+            "dev": true
+        },
+        "netrc": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
+            "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
+            "dev": true
+        },
+        "nopt": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+            "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1.1.1"
+            }
+        },
+        "noptify": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+            "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
+            "dev": true,
+            "requires": {
+                "nopt": "2.0.0"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                    "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1.1.1"
+                    }
+                }
+            }
+        },
+        "object-assign": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
+            "integrity": "sha1-Bg4qKifXwNd+x3t48Rqkf9iACNI=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            }
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
+            "requires": {
+                "lcid": "1.0.0"
+            }
+        },
+        "pac-proxy-agent": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-0.2.0.tgz",
+            "integrity": "sha1-rZApCdkvT+fMLl9Z9b9QYbz6cbI=",
+            "dev": true,
+            "requires": {
+                "agent-base": "1.0.2",
+                "debug": "2.6.9",
+                "extend": "1.2.1",
+                "get-uri": "0.1.4",
+                "pac-resolver": "1.2.6",
+                "proxy-agent": "1.1.1",
+                "stream-to-array": "1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "extend": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+                    "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=",
+                    "dev": true
+                }
+            }
+        },
+        "pac-resolver": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-1.2.6.tgz",
+            "integrity": "sha1-7QOvDFtZM1Bb3T8H91F1Rm1efPs=",
+            "dev": true,
+            "requires": {
+                "co": "3.0.6",
+                "degenerator": "1.0.4",
+                "netmask": "1.0.6",
+                "regenerator": "0.8.46",
+                "thunkify": "2.1.2"
+            },
+            "dependencies": {
+                "co": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
+                    "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
+                    "dev": true
+                }
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "postcss": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-2.2.6.tgz",
+            "integrity": "sha1-wENE4kSeRYa5Vfvkp093CA2EVx8=",
+            "dev": true,
+            "requires": {
+                "js-base64": "2.1.9",
+                "source-map": "0.1.43"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "proxy-agent": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-1.1.1.tgz",
+            "integrity": "sha1-/LHu9eWJZcmV+TjwKdcp/IGFi5U=",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "0.2.7",
+                "https-proxy-agent": "0.3.6",
+                "lru-cache": "2.5.2",
+                "pac-proxy-agent": "0.2.0",
+                "socks-proxy-agent": "1.0.2"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz",
+                    "integrity": "sha1-H92tk4quEmPOE4aAvhs/WRwKtBw=",
+                    "dev": true
+                }
+            }
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
+        "qs": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+            "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8=",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz",
+            "integrity": "sha1-zMfd/Ea3KGHN1btDPIQLcLbyf1Q=",
+            "dev": true,
+            "requires": {
+                "bytes": "1.0.0",
+                "iconv-lite": "0.4.8"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.8",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+                    "integrity": "sha1-xgGadZXyzvynAuq2lKAQvNkpjSA=",
+                    "dev": true
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "recast": {
+            "version": "0.10.33",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+            "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.8.12",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.8",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.8.12",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                    "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+                    "dev": true
+                },
+                "esprima-fb": {
+                    "version": "15001.1001.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                    "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "reduce-component": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+            "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+            "dev": true
+        },
+        "regenerator": {
+            "version": "0.8.46",
+            "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.46.tgz",
+            "integrity": "sha1-FUwydoY2HtUsrWmyVF78U6PQdpY=",
+            "dev": true,
+            "requires": {
+                "commoner": "0.10.8",
+                "defs": "1.1.1",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.8",
+                "recast": "0.10.33",
+                "regenerator-runtime": "0.9.6",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "esprima-fb": {
+                    "version": "15001.1001.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                    "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                    "dev": true
+                }
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.9.6",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+            "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "requires": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/requires/-/requires-1.0.2.tgz",
+            "integrity": "sha1-djBOghNFYi/j+sCwcRoeTygo8Po=",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                }
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "sane": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-0.8.1.tgz",
+            "integrity": "sha1-JDpLIECBvlWTwKIrC7sRVzUS/Mc=",
+            "dev": true,
+            "requires": {
+                "minimatch": "0.2.14",
+                "walker": "1.0.7",
+                "watch": "0.10.0"
+            }
+        },
+        "semver": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+            "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI=",
+            "dev": true
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "simple-fmt": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+            "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
+            "dev": true
+        },
+        "simple-is": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+            "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
+            "dev": true
+        },
+        "smart-buffer": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+            "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
+            "dev": true
+        },
+        "socks": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+            "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+            "dev": true,
+            "requires": {
+                "ip": "1.1.5",
+                "smart-buffer": "1.1.15"
+            }
+        },
+        "socks-proxy-agent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-1.0.2.tgz",
+            "integrity": "sha1-Z+BrRH/lY3QX/eVzPL/f7J/+EX8=",
+            "dev": true,
+            "requires": {
+                "agent-base": "1.0.2",
+                "extend": "1.2.1",
+                "socks": "1.1.10"
+            },
+            "dependencies": {
+                "extend": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+                    "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=",
+                    "dev": true
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+            "dev": true,
+            "requires": {
+                "amdefine": "1.0.1"
+            }
+        },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "stable": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
+            "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
+            "dev": true
+        },
+        "statuses": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+            "dev": true
+        },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1"
+            }
+        },
+        "stream-to-array": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-1.0.0.tgz",
+            "integrity": "sha1-lBZrsp8+ok8ILS+M0+uyzA1uyiw=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "stringmap": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+            "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
+            "dev": true
+        },
+        "stringset": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+            "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
+            "dev": true
+        },
+        "superagent": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.17.0.tgz",
+            "integrity": "sha1-qtzVD75ak+cZkRGNeb8HFNYlu6g=",
+            "dev": true,
+            "requires": {
+                "cookiejar": "1.3.0",
+                "debug": "0.7.4",
+                "emitter-component": "1.0.0",
+                "extend": "1.2.1",
+                "formidable": "1.0.14",
+                "methods": "0.0.1",
+                "mime": "1.2.5",
+                "qs": "0.6.5",
+                "reduce-component": "1.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "0.7.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                    "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+                    "dev": true
+                },
+                "extend": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+                    "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=",
+                    "dev": true
+                }
+            }
+        },
+        "syntax-error": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+            "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
+            "dev": true,
+            "requires": {
+                "acorn": "4.0.13"
+            }
+        },
+        "tar": {
+            "version": "0.1.20",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+            "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
+            "dev": true,
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "0.1.31",
+                "inherits": "2.0.3"
+            }
+        },
+        "tempfile": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
+            "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
+            "dev": true,
+            "requires": {
+                "uuid": "1.4.2"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "thunkify": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+            "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+            "dev": true
+        },
+        "tiny-lr-fork": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+            "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
+            "dev": true,
+            "requires": {
+                "debug": "0.7.4",
+                "faye-websocket": "0.4.4",
+                "noptify": "0.0.3",
+                "qs": "0.5.6"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "0.7.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                    "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+                    "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
+                    "dev": true
+                }
+            }
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
+        "to-descriptor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-descriptor/-/to-descriptor-1.0.1.tgz",
+            "integrity": "sha1-oOZ4w068fS2uRk2DcrwhR52cK80=",
+            "dev": true
+        },
+        "tryor": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+            "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
+        },
+        "underscore.string": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+            "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+            "dev": true
+        },
+        "unglob": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unglob/-/unglob-0.1.2.tgz",
+            "integrity": "sha1-8uwGKE5JGhx3YRp2CouOowAnLDg=",
+            "dev": true,
+            "requires": {
+                "generator-supported": "0.0.1",
+                "glob": "3.2.11",
+                "minimatch": "0.2.14"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz",
+            "integrity": "sha1-RTAZ9oaWam34PNxSROfJkOzDMvw=",
+            "dev": true
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.11"
+            }
+        },
+        "watch": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+            "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+            "dev": true
+        },
+        "win-fork": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/win-fork/-/win-fork-1.1.1.tgz",
+            "integrity": "sha1-j1jgZW/KAK3IyGoriePNLWotXl4=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write-to": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/write-to/-/write-to-1.1.1.tgz",
+            "integrity": "sha1-Xu+/aC0SjCqwwF9l3xA4c54GxqM=",
+            "dev": true,
+            "requires": {
+                "dethroy": "1.0.2",
+                "mkdirp": "0.3.5"
+            }
+        },
+        "xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "3.27.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+            "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+            "dev": true,
+            "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "os-locale": "1.4.0",
+                "window-size": "0.1.4",
+                "y18n": "3.2.1"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
-    "name": "assertion-error"
-  , "version": "1.0.2"
-  , "description": "Error constructor for test and validation frameworks that implements standardized AssertionError specification."
-  , "author": "Jake Luer <jake@qualiancy.com> (http://qualiancy.com)"
-  , "license": "MIT"
-  , "keywords": [
-        "test"
-      , "assertion"
-      , "assertion-error"
-    ]
-  , "repository": {
-        "type": "git"
-      , "url": "git@github.com:chaijs/assertion-error.git"
-    }
-  , "engines": {
-      "node": "*"
-    }
-  , "main": "./index"
-  , "scripts": {
-      "test": "make test"
-    }
-  , "dependencies": {}
-  , "devDependencies": {
-        "component": "*"
+    "name": "assertion-error",
+    "version": "1.0.2",
+    "description": "Error constructor for test and validation frameworks that implements standardized AssertionError specification.",
+    "author": "Jake Luer <jake@qualiancy.com> (http://qualiancy.com)",
+    "license": "MIT",
+    "types": "./index.d.ts",
+    "keywords": [
+        "test",
+        "assertion",
+        "assertion-error"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:chaijs/assertion-error.git"
+    },
+    "engines": {
+        "node": "*"
+    },
+    "main": "./index",
+    "scripts": {
+        "test": "make test"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "component": "*",
+        "typescript": "^2.6.1"
     }
 }

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,0 +1,14 @@
+import AssertionError = require('../index');
+
+const str: string = "";
+let e: AssertionError;
+
+function foo () { }
+
+e = new AssertionError(str);
+e = new AssertionError(str, {a:1, b:2});
+e = new AssertionError(str, {a:1, b:2}, foo);
+
+const assertionError: AssertionError<{ bar: number }> = new AssertionError("msg", { bar: 42 });
+const msg: string = assertionError.message;
+const bar: number = assertionError.bar;


### PR DESCRIPTION
Adds TypeScript as a dev dependency and specifies `index.d.ts` as typings, with `--noEmit` tests run as part of `test`.

Fixes #10.