### PR TITLE
chore: Release 1.1.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.1.0 / 2018-01-02
+==================
+
+  * Add type definitions ([#11](https://github.com/chaijs/assertion-error/pull/11))
+
 1.0.1 / 2015-03-04
 ==================
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "assertion-error",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -88,7 +88,7 @@
             "integrity": "sha1-reXOni2dcbt//DHWlvpeh66+tjQ=",
             "dev": true,
             "requires": {
-                "caniuse-db": "1.0.30000783",
+                "caniuse-db": "1.0.30000784",
                 "postcss": "2.2.6"
             }
         },
@@ -161,9 +161,9 @@
             "dev": true
         },
         "caniuse-db": {
-            "version": "1.0.30000783",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
-            "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
+            "version": "1.0.30000784",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000784.tgz",
+            "integrity": "sha1-G+lQEtlInHcZB0+BruV9vf/mNhs=",
             "dev": true
         },
         "center-align": {
@@ -238,7 +238,7 @@
             "dev": true,
             "requires": {
                 "commander": "2.12.2",
-                "detective": "4.7.0",
+                "detective": "4.7.1",
                 "glob": "5.0.15",
                 "graceful-fs": "4.1.11",
                 "iconv-lite": "0.4.19",
@@ -696,19 +696,19 @@
             }
         },
         "detective": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.0.tgz",
-            "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+            "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
+                "acorn": "5.3.0",
                 "defined": "1.0.0"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-                    "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+                    "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
                     "dev": true
                 }
             }
@@ -1873,6 +1873,12 @@
             "requires": {
                 "prelude-ls": "1.1.2"
             }
+        },
+        "typescript": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+            "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+            "dev": true
         },
         "underscore.string": {
             "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "assertion-error",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Error constructor for test and validation frameworks that implements standardized AssertionError specification.",
     "author": "Jake Luer <jake@qualiancy.com> (http://qualiancy.com)",
     "license": "MIT",


### PR DESCRIPTION
- Add type definitions (#11)

This commit bumps the version number (following https://github.com/chaijs/assertion-error/pull/11#issuecomment-354740047).

It is a semver minor update because type definitions are a feature in my opinion. Even if they don't change runtime, formalizing the documentation as types allows Typescript users to benefit from type checking.

cc @keithamus 