### PR TITLE
Added power support for the travis.yml file with ppc64le. package: assertion-error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - 0.10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ arch:
   - amd64
   - ppc64le
 node_js:
-  - 0.10
+  - '10'
+  - '12'
+  - '14'
 
 deploy:
   provider: npm


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.

updated versions  node_js:
  - '10'
  - '12'
  - '14'