### PR TITLE
Remove `posttest` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "scripts": {
     "build": "deno bundle mod.ts > index.js",
     "pretest": "rm -rf coverage/",
-    "test": "deno test --coverage=coverage",
-    "posttest": "deno coverage coverage --lcov > coverage/lcov.info && lcov --summary coverage/lcov.info"
+    "test": "deno test --coverage=coverage"
   }
 }


### PR DESCRIPTION
We can probably remove this since we aren't doing coverage in deno anymore.