### PR TITLE
Drop `NODE_AUTH_TOKEN` from publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 14
+          node-version: 25
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build --if-present

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,3 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
       - run: npm --ignore-scripts publish
-        env:
-         NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
This now uses OIDC