### PR TITLE
Deprecate history.md file like in main Chai repository

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,7 @@
 ### Note
 
-As of 2.0.0, the History.md file has been deprecated.
-Please refer to the [full commit logs available on GitHub](https://github.com/chaijs/assertion-error/commits/).
+As of 2.0.0, the History.md file has been deprecated. Please refer to the
+[full commit logs available on GitHub](https://github.com/chaijs/assertion-error/commits/).
 
 ---
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+### Note
+
+As of 2.0.0, the History.md file has been deprecated.
+Please refer to the [full commit logs available on GitHub](https://github.com/chaijs/assertion-error/commits/).
+
+---
+
 # 1.1.0 / 2018-01-02
 
 - Add type definitions


### PR DESCRIPTION
I was trying to check something in the AssertionError changelog, and I noticed the History.md file doesn't seem to be updated any more in this repo.

I can see the main Chai repository History.md file is deprecated in favour of GitHub history (https://github.com/chaijs/chai/blob/main/History.md), so it seems sensible to deprecated this one the same way.

